### PR TITLE
Added getClubCampaignById

### DIFF
--- a/src/lib/api/live-services.spec.ts
+++ b/src/lib/api/live-services.spec.ts
@@ -1,201 +1,431 @@
-import dotenv from 'dotenv'
-dotenv.config()
-
-import anyTest, { TestInterface } from 'ava'
-
-import {
-    getSeasons,
-    getTOTDs,
-    getClubCampaigns,
-    getMyGroupRecords,
-    getMyPositionGroup,
-    getTopPlayersGroup,
-    getTopPlayersMap,
-    getTopGroupPlayersMap,
-    getSurroundingPlayersMap,
-    getClubRooms,
-    getArcadeRooms,
-    getClubs,
-    getClubMembers,
-    getPlayerRankings,
-    getLeaderboardsAroundScore,
-} from './live-services'
-
-import credentials from '../../config/test.json'
-
-const test = anyTest as TestInterface<{
-    account: { lv2liveAccessToken: string; accountId: string }
-}>
-
-test.before(async t => {
-    const { accountId, lv2liveAccessToken } = (credentials as unknown) as {
-        lv2liveAccessToken: null | string
-        accountId: null | string
-    }
-    if (accountId && lv2liveAccessToken)
-        t.context.account = { lv2liveAccessToken, accountId }
-})
-
-test('Get all seasons', async t => {
-    try {
-        const response = await getSeasons(t.context.account.lv2liveAccessToken)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get all TOTDs', async t => {
-    try {
-        const response = await getTOTDs(t.context.account.lv2liveAccessToken)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('List club campaigns', async t => {
-    try {
-        const response = await getClubCampaigns(t.context.account.lv2liveAccessToken)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get my group records', async t => {
-    try {
-        const response = await getMyGroupRecords(
-            t.context.account.lv2liveAccessToken,
-            '3987d489-03ae-4645-9903-8f7679c3a418',
-        )
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get my position in a group', async t => {
-    try {
-        const response = await getMyPositionGroup(
-            t.context.account.lv2liveAccessToken,
-            '3987d489-03ae-4645-9903-8f7679c3a418',
-        )
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get top players from a group', async t => {
-    try {
-        const response = await getTopPlayersGroup(
-            t.context.account.lv2liveAccessToken,
-            '3987d489-03ae-4645-9903-8f7679c3a418',
-        )
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get top players from a group and a map', async t => {
-    try {
-        const response = await getTopGroupPlayersMap(
-            t.context.account.lv2liveAccessToken,
-            '3987d489-03ae-4645-9903-8f7679c3a418',
-            'XJ_JEjWGoAexDWe8qfaOjEcq5l8',
-        )
-
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get leaderboards around a score', async t => {
-    try {
-        const response = await getLeaderboardsAroundScore(
-            t.context.account.lv2liveAccessToken,
-            '3987d489-03ae-4645-9903-8f7679c3a418',
-            'XJ_JEjWGoAexDWe8qfaOjEcq5l8',
-            19598,
-        )
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get top players from a map', async t => {
-    try {
-        const response = await getTopPlayersMap(
-            t.context.account.lv2liveAccessToken,
-            'XJ_JEjWGoAexDWe8qfaOjEcq5l8',
-        )
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get surrounding players from a map', async t => {
-    try {
-        const response = await getSurroundingPlayersMap(
-            t.context.account.lv2liveAccessToken,
-            'XJ_JEjWGoAexDWe8qfaOjEcq5l8',
-        )
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get club rooms', async t => {
-    try {
-        const response = await getClubRooms(t.context.account.lv2liveAccessToken)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get arcade rooms', async t => {
-    try {
-        const response = await getArcadeRooms(t.context.account.lv2liveAccessToken)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get clubs', async t => {
-    try {
-        const response = await getClubs(t.context.account.lv2liveAccessToken)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get club members', async t => {
-    try {
-        const response = await getClubMembers(t.context.account.lv2liveAccessToken, 1)
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
-
-test('Get player rankings', async t => {
-    try {
-        const response = await getPlayerRankings(t.context.account.lv2liveAccessToken, [
-            'a9cbdeff-daa3-4bc2-998c-b2838183fb97',
-            '531a9861-c024-4063-9b29-14601350b899',
-            '2ed0997d-62bc-4a53-8c09-ffb793382ea2',
-        ])
-        t.assert(response)
-    } catch (err) {
-        t.fail(JSON.stringify(err.response.data))
-    }
-})
+/**
+ * Obtain all the seasons, including seasonsIds, groupIds, mapIds, etc.
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} offset - Offset (default = 0)
+ * @param {number} length - Length (default = 1)
+ *
+ */
+export declare const getSeasons: (accessToken: string, offset?: number, length?: number) => Promise<IallSeasons>;
+/**
+ * Obtain all the track of the days, with their respective mapUid and seasonUid
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} offset - Offset (default = 0)
+ * @param {number} length - Length (default = 1)
+ *
+ */
+export declare const getTOTDs: (accessToken: string, offset?: number, length?: number) => Promise<ITOTDs>;
+/**
+ * List clubs campaigns (used when we are in Solo Screen and looking for Club Campaigns)
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} offset - Offset (default = 0)
+ * @param {number} length - Length (default = 75)
+ * @param {string} sort - Sort (default = 'popularity')
+ * @param {string} order - Order (default = 'DESC')
+ *
+ */
+export declare const getClubCampaigns: (accessToken: string, offset?: number, length?: number, sort?: string, order?: string) => Promise<IclubCampaigns>;
+/**
+ * Returns info about the campaign based on both the campaignId and the clubId (used in Clubs)
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} clubId - Club ID
+ * @param {number} campaignId - Campaign ID
+ *
+ */
+export declare const getClubCampaignById: (accessToken: string, clubId: number, campaignId: number) => Promise<IclubCampaign>;
+/**
+ * Returns your record in everymap of that group, and your position in each zone
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} groupUid - Group uid
+ *
+ */
+export declare const getMyGroupRecords: (accessToken: string, groupUid: string) => Promise<IgroupRecords>;
+/**
+ * Get your position in a group (ex: overall ranking on Summer Season 2020 in world, country, etc.)
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} groupUid - Group uid
+ *
+ */
+export declare const getMyPositionGroup: (accessToken: string, groupUid: string) => Promise<IpositionGroup>;
+/**
+ * Get the top leaders on a group (ex: top rankings on Summer Season 2020 in world, country, etc.)
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} groupUid - Group uid
+ *
+ */
+export declare const getTopPlayersGroup: (accessToken: string, groupUid: string) => Promise<IgroupTopPlayers>;
+/**
+ * Obtain the top players on a specific map from a specific group
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} groupUid - Group uid
+ * @param {string} mapUid - Map uid
+ *
+ */
+export declare const getTopGroupPlayersMap: (accessToken: string, groupUid: string, mapUid: string) => Promise<ImapTopPlayer>;
+/**
+ * Obtain the leaderboards around a score
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} groupUid - Group uid
+ * @param {string} mapUid - Map uid
+ * @param {number} score - Score
+ *
+ */
+export declare const getLeaderboardsAroundScore: (accessToken: string, groupUid: string, mapUid: string, score: number) => Promise<ImapTopPlayer>;
+/**
+ * Get the top players of a map, with no restriction of a group like the others endpoints
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} mapUid - Map uid
+ *
+ */
+export declare const getTopPlayersMap: (accessToken: string, mapUid: string) => Promise<ImapTopPlayer>;
+/**
+ * Get the surrounding players around your score on a map, with no restriction of a group like the others endpoints (this is used in that little leaderboard in game)
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string} mapUid - Map uid
+ *
+ */
+export declare const getSurroundingPlayersMap: (accessToken: string, mapUid: string) => Promise<ImapTopPlayer>;
+/**
+ * This is used to obtain the clubs in the Live section of the game
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} offset - Offset (default = 0)
+ * @param {number} length - Length (default = 75)
+ * @param {string} sort - Sort (default = 'popularity')
+ * @param {string} order - Order (default = 'DESC')
+ *
+ */
+export declare const getClubRooms: (accessToken: string, offset?: number, length?: number, sort?: string, order?: string) => Promise<IclubRooms>;
+/**
+ * Obtain the information about the current arcade room and the next room
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ *
+ */
+export declare const getArcadeRooms: (accessToken: string) => Promise<IarcadeRooms>;
+/**
+ * List all the clubs in the club section
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} offset - Offset (default = 0)
+ * @param {number} length Length (default = 90)
+ *
+ */
+export declare const getClubs: (accessToken: string, offset?: number, length?: number) => Promise<Iclubs>;
+/**
+ * Obtain all the information about the members of a club
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} clubId - Clubid
+ * @param {number} offset - Offset (default = 0)
+ * @param {number} length - Length (default = 27)
+ *
+ */
+export declare const getClubMembers: (accessToken: string, clubId: number, offset?: number, length?: number) => Promise<IclubMembers>;
+/**
+ * Obtain player rankings
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {string[]} accountIds - Account ids
+ *
+ */
+export declare const getPlayerRankings: (accessToken: string, accountIds: string[]) => Promise<any>;
+export interface IallSeasons {
+    campaignList: campaign[];
+    itemCount: number;
+}
+declare type campaign = {
+    id: number;
+    seasonUid: string;
+    name: string;
+    color: string;
+    useCase: number;
+    clubId: unknown;
+    leaderboardGroupUid: string;
+    publicationTimestamp: number;
+    publishedDate: number;
+    year: number;
+    week: number;
+    day: number;
+    monthYear: number;
+    month: number;
+    monthDay: number;
+    published: boolean;
+    playlist: playlist[];
+    latestSeasons: latestSeason[];
+    categories: category[];
+    media: media;
+};
+declare type playlist = {
+    id: number;
+    position: number;
+    mapUid: string;
+};
+declare type latestSeason = {
+    uid: string;
+    name: string;
+    startTimestamp: number;
+    startDate: number;
+    endTimestamp: number;
+    endDate: number;
+    relativeStart: number;
+    relativeEnd: number;
+    campaignId: number;
+    active: boolean;
+};
+declare type category = {
+    position: number;
+    length: number;
+    name: string;
+};
+declare type media = {
+    buttonBackgroundUrl: string;
+    buttonForegroundUrl: string;
+    popUpBackgroundUrl: string;
+    popUpImageUrl: string;
+    liveButtonBackgroundUrl: string;
+};
+export interface ITOTDs {
+    monthList: month[];
+    itemCount: number;
+}
+declare type month = {
+    year: number;
+    month: number;
+    lastDay: number;
+    days: day[];
+    media: media;
+};
+declare type day = {
+    campaignId: number;
+    mapUid: string;
+    day: number;
+    monthDay: number;
+    seasonUid: string;
+    relativeStart: number;
+    relativeEnd: number;
+    leaderboardGroup: unknown;
+};
+export interface IclubCampaigns {
+    clubCampaignList: clubCampaign[];
+    maxPage: number;
+    itemCount: number;
+}
+declare type clubCampaign = {
+    clubId: number;
+    clubIconUrl: string;
+    clubDecalUrl: string;
+    campaignId: number;
+    publicationTimestamp: number;
+    publishedOn: number;
+    creationTimestamp: number;
+    activityId: number;
+    mediaUrl: string;
+    name: string;
+    campaign: campaign;
+    popularityLevel: number;
+};
+export interface IclubCampaign {
+    clubId: number;
+    clubIconUrl: string;
+    clubDecalUrl: string;
+    campaignId: number;
+    publicationTimestamp: number;
+    publishedOn: number;
+    creationTimestamp: number;
+    activityId: number;
+    mediaUrl: string;
+    name: string;
+    campaign: campaign;
+    popularityLevel: number;
+}
+export interface IgroupRecords {
+    [key: string]: record;
+}
+declare type record = {
+    groupUid: string;
+    mapUid: string;
+    score: number;
+    zones: zone[];
+};
+declare type zone = {
+    zoneId: string;
+    zoneName: string;
+    ranking: ranking;
+};
+declare type ranking = {
+    position: number;
+    length: number;
+};
+export interface IpositionGroup {
+    groupUid: string;
+    sp: number;
+    zones: zone[];
+}
+export interface IgroupTopPlayers {
+    groupUid: string;
+    tops: tops[];
+}
+declare type tops = {
+    zoneId: string;
+    zoneName: string;
+    top: top[];
+};
+declare type top = {
+    accountId: string;
+    zoneId: string;
+    zoneName: string;
+    position: number;
+    sp?: number;
+    score?: number;
+};
+export interface ImapTopPlayer {
+    groupUid: string;
+    mapUid: string;
+    tops: tops[];
+}
+export interface IclubRooms {
+    clubRoomList: clubRoom[];
+    maxPage: number;
+    itemCount: number;
+}
+declare type clubRoom = {
+    id: number;
+    clubId: number;
+    nadeo: boolean;
+    roomId: number;
+    campaignId: unknown;
+    playerServerLogin: unknown;
+    activityId: number;
+    mediaUrl: string;
+    name: string;
+    room: room;
+    popularityLevel: number;
+    creationTimestamp: number;
+};
+declare type room = {
+    id: number;
+    name: string;
+    region: unknown;
+    serverAccountId: string;
+    maxPlayers: number;
+    playerCount: number;
+    maps: string[];
+    script: string;
+    scriptSettings: scriptSettings;
+};
+declare type scriptSettings = {
+    S_ForceLapsNb: {
+        key: string;
+        value: string;
+        type: string;
+    };
+    S_DecoImageUrl_Screen16x9: {
+        key: string;
+        value: string;
+        type: string;
+    };
+};
+export interface IarcadeRooms {
+    uid: string;
+    name: string;
+    playerCount: number;
+    currentTimeSlot: timeSlot;
+    nextTimeSlot: timeSlot;
+}
+declare type timeSlot = {
+    startTimestamp: number;
+    endTimestamp: number;
+    name: string;
+    maps: string[];
+    currentMap: string;
+    relativeStart: number;
+    relativeEnd: number;
+    mediaUrl: string;
+};
+export interface Iclubs {
+    clubList: unknown[];
+    maxPage: number;
+    clubCount: number;
+}
+export interface IclubMembers {
+    clubMemberList: clubMember[];
+    maxPage: number;
+    itemCount: number;
+}
+declare type clubMember = {
+    accountId: string;
+    role: string;
+    creationTimestamp: number;
+    creationDate: number;
+    vip: boolean;
+};
+export interface IleaderboardsAroundScore {
+    groupUid: string;
+    mapUid: string;
+    levels: level[];
+}
+declare type level = {
+    zoneId: string;
+    zoneName: string;
+    level: top[];
+};
+export {};

--- a/src/lib/api/live-services.ts
+++ b/src/lib/api/live-services.ts
@@ -1,7 +1,11 @@
-import axios from 'axios'
-
-import { urls, setHeaders } from '../main'
-
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getPlayerRankings = exports.getClubMembers = exports.getClubs = exports.getArcadeRooms = exports.getClubRooms = exports.getSurroundingPlayersMap = exports.getTopPlayersMap = exports.getLeaderboardsAroundScore = exports.getTopGroupPlayersMap = exports.getTopPlayersGroup = exports.getMyPositionGroup = exports.getMyGroupRecords = exports.getClubCampaigns = exports.getTOTDs = exports.getSeasons = void 0;
+const axios_1 = __importDefault(require("axios"));
+const main_1 = require("../main");
 /**
  * Obtain all the seasons, including seasonsIds, groupIds, mapIds, etc.
  *
@@ -13,26 +17,19 @@ import { urls, setHeaders } from '../main'
  * @param {number} length - Length (default = 1)
  *
  */
-export const getSeasons = async (
-    accessToken: string,
-    offset: number = 0,
-    length: number = 1,
-): Promise<IallSeasons> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getSeasons = async (accessToken, offset = 0, length = 1) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/campaign/official?offset=' +
             offset +
             '&length=' +
             length,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Obtain all the track of the days, with their respective mapUid and seasonUid
  *
@@ -44,26 +41,19 @@ export const getSeasons = async (
  * @param {number} length - Length (default = 1)
  *
  */
-export const getTOTDs = async (
-    accessToken: string,
-    offset: number = 0,
-    length: number = 1,
-): Promise<ITOTDs> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getTOTDs = async (accessToken, offset = 0, length = 1) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/campaign/month?offset=' +
             offset +
             '&length=' +
             length,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * List clubs campaigns (used when we are in Solo Screen and looking for Club Campaigns)
  *
@@ -77,17 +67,10 @@ export const getTOTDs = async (
  * @param {string} order - Order (default = 'DESC')
  *
  */
-export const getClubCampaigns = async (
-    accessToken: string,
-    offset: number = 0,
-    length: number = 75,
-    sort: string = 'popularity',
-    order: string = 'DESC',
-): Promise<IclubCampaigns> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getClubCampaigns = async (accessToken, offset = 0, length = 75, sort = 'popularity', order = 'DESC') => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/club/campaign?offset=' +
             offset +
             '&length=' +
@@ -98,11 +81,33 @@ export const getClubCampaigns = async (
             order,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
+/**
+ * Returns info about the campaign based on both the campaignId and the clubId (used in Clubs)
+ *
+ * ## **Requires level 2 authentication**
+ *
+ * @category level 2
+ * @param {string} accessToken - Access token
+ * @param {number} clubId - Club ID
+ * @param {number} campaignId - Campaign ID
+ *
+ */
+exports.getClubCampaignById = async (accessToken, clubId, campaignId) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
+            '/api/token/club/' +
+            clubId +
+            '/campaign/' +
+            campaignId,
+        method: 'GET',
+        headers,
+    });
+    return response['data'];
+};
 /**
  * Returns your record in everymap of that group, and your position in each zone
  *
@@ -113,20 +118,15 @@ export const getClubCampaigns = async (
  * @param {string} groupUid - Group uid
  *
  */
-export const getMyGroupRecords = async (
-    accessToken: string,
-    groupUid: string,
-): Promise<IgroupRecords> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url: urls.liveServices + '/api/token/leaderboard/group/' + groupUid + '/map',
+exports.getMyGroupRecords = async (accessToken, groupUid) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices + '/api/token/leaderboard/group/' + groupUid + '/map',
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Get your position in a group (ex: overall ranking on Summer Season 2020 in world, country, etc.)
  *
@@ -137,20 +137,15 @@ export const getMyGroupRecords = async (
  * @param {string} groupUid - Group uid
  *
  */
-export const getMyPositionGroup = async (
-    accessToken: string,
-    groupUid: string,
-): Promise<IpositionGroup> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url: urls.liveServices + '/api/token/leaderboard/group/' + groupUid,
+exports.getMyPositionGroup = async (accessToken, groupUid) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices + '/api/token/leaderboard/group/' + groupUid,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Get the top leaders on a group (ex: top rankings on Summer Season 2020 in world, country, etc.)
  *
@@ -161,20 +156,15 @@ export const getMyPositionGroup = async (
  * @param {string} groupUid - Group uid
  *
  */
-export const getTopPlayersGroup = async (
-    accessToken: string,
-    groupUid: string,
-): Promise<IgroupTopPlayers> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url: urls.liveServices + '/api/token/leaderboard/group/' + groupUid + '/top',
+exports.getTopPlayersGroup = async (accessToken, groupUid) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices + '/api/token/leaderboard/group/' + groupUid + '/top',
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Obtain the top players on a specific map from a specific group
  *
@@ -186,15 +176,10 @@ export const getTopPlayersGroup = async (
  * @param {string} mapUid - Map uid
  *
  */
-export const getTopGroupPlayersMap = async (
-    accessToken: string,
-    groupUid: string,
-    mapUid: string,
-): Promise<ImapTopPlayer> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getTopGroupPlayersMap = async (accessToken, groupUid, mapUid) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/leaderboard/group/' +
             groupUid +
             '/map/' +
@@ -202,11 +187,9 @@ export const getTopGroupPlayersMap = async (
             '/top',
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Obtain the leaderboards around a score
  *
@@ -219,16 +202,10 @@ export const getTopGroupPlayersMap = async (
  * @param {number} score - Score
  *
  */
-export const getLeaderboardsAroundScore = async (
-    accessToken: string,
-    groupUid: string,
-    mapUid: string,
-    score: number,
-): Promise<ImapTopPlayer> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getLeaderboardsAroundScore = async (accessToken, groupUid, mapUid, score) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/leaderboard/group/' +
             groupUid +
             '/map/' +
@@ -237,11 +214,9 @@ export const getLeaderboardsAroundScore = async (
             score,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Get the top players of a map, with no restriction of a group like the others endpoints
  *
@@ -252,24 +227,18 @@ export const getLeaderboardsAroundScore = async (
  * @param {string} mapUid - Map uid
  *
  */
-export const getTopPlayersMap = async (
-    accessToken: string,
-    mapUid: string,
-): Promise<ImapTopPlayer> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getTopPlayersMap = async (accessToken, mapUid) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/leaderboard/group/Personal_Best/map/' +
             mapUid +
             '/top',
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Get the surrounding players around your score on a map, with no restriction of a group like the others endpoints (this is used in that little leaderboard in game)
  *
@@ -280,24 +249,18 @@ export const getTopPlayersMap = async (
  * @param {string} mapUid - Map uid
  *
  */
-export const getSurroundingPlayersMap = async (
-    accessToken: string,
-    mapUid: string,
-): Promise<ImapTopPlayer> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getSurroundingPlayersMap = async (accessToken, mapUid) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/leaderboard/group/Personal_Best/map/' +
             mapUid +
             '/surround/1/1',
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * This is used to obtain the clubs in the Live section of the game
  *
@@ -311,17 +274,10 @@ export const getSurroundingPlayersMap = async (
  * @param {string} order - Order (default = 'DESC')
  *
  */
-export const getClubRooms = async (
-    accessToken: string,
-    offset: number = 0,
-    length: number = 75,
-    sort: string = 'popularity',
-    order: string = 'DESC',
-): Promise<IclubRooms> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getClubRooms = async (accessToken, offset = 0, length = 75, sort = 'popularity', order = 'DESC') => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/club/room?offset=' +
             offset +
             '&length=' +
@@ -332,11 +288,9 @@ export const getClubRooms = async (
             order,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Obtain the information about the current arcade room and the next room
  *
@@ -346,17 +300,15 @@ export const getClubRooms = async (
  * @param {string} accessToken - Access token
  *
  */
-export const getArcadeRooms = async (accessToken: string): Promise<IarcadeRooms> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url: urls.liveServices + '/api/token/channel/officialhard',
+exports.getArcadeRooms = async (accessToken) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices + '/api/token/channel/officialhard',
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * List all the clubs in the club section
  *
@@ -368,26 +320,19 @@ export const getArcadeRooms = async (accessToken: string): Promise<IarcadeRooms>
  * @param {number} length Length (default = 90)
  *
  */
-export const getClubs = async (
-    accessToken: string,
-    offset: number = 0,
-    length: number = 90,
-): Promise<Iclubs> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getClubs = async (accessToken, offset = 0, length = 90) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/club/mine?offset=' +
             offset +
             '&length=' +
             length,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Obtain all the information about the members of a club
  *
@@ -400,16 +345,10 @@ export const getClubs = async (
  * @param {number} length - Length (default = 27)
  *
  */
-export const getClubMembers = async (
-    accessToken: string,
-    clubId: number,
-    offset: number = 0,
-    length: number = 27,
-): Promise<IclubMembers> => {
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url:
-            urls.liveServices +
+exports.getClubMembers = async (accessToken, clubId, offset = 0, length = 27) => {
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices +
             '/api/token/club/' +
             clubId +
             '/member?offset=' +
@@ -418,11 +357,9 @@ export const getClubMembers = async (
             length,
         method: 'GET',
         headers,
-    })
-
-    return response['data']
-}
-
+    });
+    return response['data'];
+};
 /**
  * Obtain player rankings
  *
@@ -433,271 +370,19 @@ export const getClubMembers = async (
  * @param {string[]} accountIds - Account ids
  *
  */
-export const getPlayerRankings = async (accessToken: string, accountIds: string[]) => {
+exports.getPlayerRankings = async (accessToken, accountIds) => {
     const obj = accountIds.map(id => {
-        return { accountId: id }
-    })
-    const headers = setHeaders(accessToken, 'nadeo')
-    const response = await axios({
-        url: urls.liveServices + '/api/token/leaderboard/trophy/player',
+        return { accountId: id };
+    });
+    const headers = main_1.setHeaders(accessToken, 'nadeo');
+    const response = await axios_1.default({
+        url: main_1.urls.liveServices + '/api/token/leaderboard/trophy/player',
         method: 'POST',
         data: {
             listPlayer: obj,
         },
         headers,
-    })
-
-    return response['data']
-}
-
-export interface IallSeasons {
-    campaignList: campaign[]
-    itemCount: number
-}
-
-type campaign = {
-    id: number
-    seasonUid: string
-    name: string
-    color: string
-    useCase: number
-    clubId: unknown
-    leaderboardGroupUid: string
-    publicationTimestamp: number
-    publishedDate: number
-    year: number
-    week: number
-    day: number
-    monthYear: number
-    month: number
-    monthDay: number
-    published: boolean
-    playlist: playlist[]
-    latestSeasons: latestSeason[]
-    categories: category[]
-    media: media
-}
-
-type playlist = {
-    id: number
-    position: number
-    mapUid: string
-}
-type latestSeason = {
-    uid: string
-    name: string
-    startTimestamp: number
-    startDate: number
-    endTimestamp: number
-    endDate: number
-    relativeStart: number
-    relativeEnd: number
-    campaignId: number
-    active: boolean
-}
-
-type category = {
-    position: number
-    length: number
-    name: string
-}
-
-type media = {
-    buttonBackgroundUrl: string
-    buttonForegroundUrl: string
-    popUpBackgroundUrl: string
-    popUpImageUrl: string
-    liveButtonBackgroundUrl: string
-}
-
-export interface ITOTDs {
-    monthList: month[]
-    itemCount: number
-}
-
-type month = {
-    year: number
-    month: number
-    lastDay: number
-    days: day[]
-    media: media
-}
-
-type day = {
-    campaignId: number
-    mapUid: string
-    day: number
-    monthDay: number
-    seasonUid: string
-    relativeStart: number
-    relativeEnd: number
-    leaderboardGroup: unknown
-}
-
-export interface IclubCampaigns {
-    clubCampaignList: clubCampaign[]
-    maxPage: number
-    itemCount: number
-}
-
-type clubCampaign = {
-    clubId: number
-    clubIconUrl: string
-    clubDecalUrl: string
-    campaignId: number
-    publicationTimestamp: number
-    publishedOn: number
-    creationTimestamp: number
-    activityId: number
-    mediaUrl: string
-    name: string
-    campaign: campaign
-    popularityLevel: number
-}
-
-export interface IgroupRecords {
-    [key: string]: record
-}
-
-type record = {
-    groupUid: string
-    mapUid: string
-    score: number
-    zones: zone[]
-}
-
-type zone = {
-    zoneId: string
-    zoneName: string
-    ranking: ranking
-}
-
-type ranking = {
-    position: number
-    length: number
-}
-
-export interface IpositionGroup {
-    groupUid: string
-    sp: number
-    zones: zone[]
-}
-
-export interface IgroupTopPlayers {
-    groupUid: string
-    tops: tops[]
-}
-
-type tops = {
-    zoneId: string
-    zoneName: string
-    top: top[]
-}
-
-type top = {
-    accountId: string
-    zoneId: string
-    zoneName: string
-    position: number
-    sp?: number
-    score?: number
-}
-
-export interface ImapTopPlayer {
-    groupUid: string
-    mapUid: string
-    tops: tops[]
-}
-
-export interface IclubRooms {
-    clubRoomList: clubRoom[]
-    maxPage: number
-    itemCount: number
-}
-
-type clubRoom = {
-    id: number
-    clubId: number
-    nadeo: boolean
-    roomId: number
-    campaignId: unknown
-    playerServerLogin: unknown
-    activityId: number
-    mediaUrl: string
-    name: string
-    room: room
-    popularityLevel: number
-    creationTimestamp: number
-}
-
-type room = {
-    id: number
-    name: string
-    region: unknown
-    serverAccountId: string
-    maxPlayers: number
-    playerCount: number
-    maps: string[]
-    script: string
-    scriptSettings: scriptSettings
-}
-
-type scriptSettings = {
-    S_ForceLapsNb: { key: string; value: string; type: string }
-    S_DecoImageUrl_Screen16x9: {
-        key: string
-        value: string
-        type: string
-    }
-}
-
-export interface IarcadeRooms {
-    uid: string
-    name: string
-    playerCount: number
-    currentTimeSlot: timeSlot
-    nextTimeSlot: timeSlot
-}
-
-type timeSlot = {
-    startTimestamp: number
-    endTimestamp: number
-    name: string
-    maps: string[]
-    currentMap: string
-    relativeStart: number
-    relativeEnd: number
-    mediaUrl: string
-}
-
-export interface Iclubs {
-    clubList: unknown[]
-    maxPage: number
-    clubCount: number
-}
-
-export interface IclubMembers {
-    clubMemberList: clubMember[]
-    maxPage: number
-    itemCount: number
-}
-
-type clubMember = {
-    accountId: string
-    role: string
-    creationTimestamp: number
-    creationDate: number
-    vip: boolean
-}
-
-export interface IleaderboardsAroundScore {
-    groupUid: string
-    mapUid: string
-    levels: level[]
-}
-
-type level = {
-    zoneId: string
-    zoneName: string
-    level: top[]
-}
+    });
+    return response['data'];
+};
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibGl2ZS1zZXJ2aWNlcy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uLy4uL3NyYy9saWIvYXBpL2xpdmUtc2VydmljZXMudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7O0FBQUEsa0RBQXlCO0FBRXpCLGtDQUEwQztBQUUxQzs7Ozs7Ozs7OztHQVVHO0FBQ1UsUUFBQSxVQUFVLEdBQUcsS0FBSyxFQUMzQixXQUFtQixFQUNuQixTQUFpQixDQUFDLEVBQ2xCLFNBQWlCLENBQUMsRUFDRSxFQUFFO0lBQ3RCLE1BQU0sT0FBTyxHQUFHLGlCQUFVLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxDQUFBO0lBQ2hELE1BQU0sUUFBUSxHQUFHLE1BQU0sZUFBSyxDQUFDO1FBQ3pCLEdBQUcsRUFDQyxXQUFJLENBQUMsWUFBWTtZQUNqQixzQ0FBc0M7WUFDdEMsTUFBTTtZQUNOLFVBQVU7WUFDVixNQUFNO1FBQ1YsTUFBTSxFQUFFLEtBQUs7UUFDYixPQUFPO0tBQ1YsQ0FBQyxDQUFBO0lBRUYsT0FBTyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUE7QUFDM0IsQ0FBQyxDQUFBO0FBRUQ7Ozs7Ozs7Ozs7R0FVRztBQUNVLFFBQUEsUUFBUSxHQUFHLEtBQUssRUFDekIsV0FBbUIsRUFDbkIsU0FBaUIsQ0FBQyxFQUNsQixTQUFpQixDQUFDLEVBQ0gsRUFBRTtJQUNqQixNQUFNLE9BQU8sR0FBRyxpQkFBVSxDQUFDLFdBQVcsRUFBRSxPQUFPLENBQUMsQ0FBQTtJQUNoRCxNQUFNLFFBQVEsR0FBRyxNQUFNLGVBQUssQ0FBQztRQUN6QixHQUFHLEVBQ0MsV0FBSSxDQUFDLFlBQVk7WUFDakIsbUNBQW1DO1lBQ25DLE1BQU07WUFDTixVQUFVO1lBQ1YsTUFBTTtRQUNWLE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7Ozs7Ozs7R0FZRztBQUNVLFFBQUEsZ0JBQWdCLEdBQUcsS0FBSyxFQUNqQyxXQUFtQixFQUNuQixTQUFpQixDQUFDLEVBQ2xCLFNBQWlCLEVBQUUsRUFDbkIsT0FBZSxZQUFZLEVBQzNCLFFBQWdCLE1BQU0sRUFDQyxFQUFFO0lBQ3pCLE1BQU0sT0FBTyxHQUFHLGlCQUFVLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxDQUFBO0lBQ2hELE1BQU0sUUFBUSxHQUFHLE1BQU0sZUFBSyxDQUFDO1FBQ3pCLEdBQUcsRUFDQyxXQUFJLENBQUMsWUFBWTtZQUNqQixrQ0FBa0M7WUFDbEMsTUFBTTtZQUNOLFVBQVU7WUFDVixNQUFNO1lBQ04sUUFBUTtZQUNSLElBQUk7WUFDSixTQUFTO1lBQ1QsS0FBSztRQUNULE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7Ozs7R0FTRztBQUNVLFFBQUEsaUJBQWlCLEdBQUcsS0FBSyxFQUNsQyxXQUFtQixFQUNuQixRQUFnQixFQUNNLEVBQUU7SUFDeEIsTUFBTSxPQUFPLEdBQUcsaUJBQVUsQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLENBQUE7SUFDaEQsTUFBTSxRQUFRLEdBQUcsTUFBTSxlQUFLLENBQUM7UUFDekIsR0FBRyxFQUFFLFdBQUksQ0FBQyxZQUFZLEdBQUcsK0JBQStCLEdBQUcsUUFBUSxHQUFHLE1BQU07UUFDNUUsTUFBTSxFQUFFLEtBQUs7UUFDYixPQUFPO0tBQ1YsQ0FBQyxDQUFBO0lBRUYsT0FBTyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUE7QUFDM0IsQ0FBQyxDQUFBO0FBRUQ7Ozs7Ozs7OztHQVNHO0FBQ1UsUUFBQSxrQkFBa0IsR0FBRyxLQUFLLEVBQ25DLFdBQW1CLEVBQ25CLFFBQWdCLEVBQ08sRUFBRTtJQUN6QixNQUFNLE9BQU8sR0FBRyxpQkFBVSxDQUFDLFdBQVcsRUFBRSxPQUFPLENBQUMsQ0FBQTtJQUNoRCxNQUFNLFFBQVEsR0FBRyxNQUFNLGVBQUssQ0FBQztRQUN6QixHQUFHLEVBQUUsV0FBSSxDQUFDLFlBQVksR0FBRywrQkFBK0IsR0FBRyxRQUFRO1FBQ25FLE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7Ozs7R0FTRztBQUNVLFFBQUEsa0JBQWtCLEdBQUcsS0FBSyxFQUNuQyxXQUFtQixFQUNuQixRQUFnQixFQUNTLEVBQUU7SUFDM0IsTUFBTSxPQUFPLEdBQUcsaUJBQVUsQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLENBQUE7SUFDaEQsTUFBTSxRQUFRLEdBQUcsTUFBTSxlQUFLLENBQUM7UUFDekIsR0FBRyxFQUFFLFdBQUksQ0FBQyxZQUFZLEdBQUcsK0JBQStCLEdBQUcsUUFBUSxHQUFHLE1BQU07UUFDNUUsTUFBTSxFQUFFLEtBQUs7UUFDYixPQUFPO0tBQ1YsQ0FBQyxDQUFBO0lBRUYsT0FBTyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUE7QUFDM0IsQ0FBQyxDQUFBO0FBRUQ7Ozs7Ozs7Ozs7R0FVRztBQUNVLFFBQUEscUJBQXFCLEdBQUcsS0FBSyxFQUN0QyxXQUFtQixFQUNuQixRQUFnQixFQUNoQixNQUFjLEVBQ1EsRUFBRTtJQUN4QixNQUFNLE9BQU8sR0FBRyxpQkFBVSxDQUFDLFdBQVcsRUFBRSxPQUFPLENBQUMsQ0FBQTtJQUNoRCxNQUFNLFFBQVEsR0FBRyxNQUFNLGVBQUssQ0FBQztRQUN6QixHQUFHLEVBQ0MsV0FBSSxDQUFDLFlBQVk7WUFDakIsK0JBQStCO1lBQy9CLFFBQVE7WUFDUixPQUFPO1lBQ1AsTUFBTTtZQUNOLE1BQU07UUFDVixNQUFNLEVBQUUsS0FBSztRQUNiLE9BQU87S0FDVixDQUFDLENBQUE7SUFFRixPQUFPLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQTtBQUMzQixDQUFDLENBQUE7QUFFRDs7Ozs7Ozs7Ozs7R0FXRztBQUNVLFFBQUEsMEJBQTBCLEdBQUcsS0FBSyxFQUMzQyxXQUFtQixFQUNuQixRQUFnQixFQUNoQixNQUFjLEVBQ2QsS0FBYSxFQUNTLEVBQUU7SUFDeEIsTUFBTSxPQUFPLEdBQUcsaUJBQVUsQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLENBQUE7SUFDaEQsTUFBTSxRQUFRLEdBQUcsTUFBTSxlQUFLLENBQUM7UUFDekIsR0FBRyxFQUNDLFdBQUksQ0FBQyxZQUFZO1lBQ2pCLCtCQUErQjtZQUMvQixRQUFRO1lBQ1IsT0FBTztZQUNQLE1BQU07WUFDTix1QkFBdUI7WUFDdkIsS0FBSztRQUNULE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7Ozs7R0FTRztBQUNVLFFBQUEsZ0JBQWdCLEdBQUcsS0FBSyxFQUNqQyxXQUFtQixFQUNuQixNQUFjLEVBQ1EsRUFBRTtJQUN4QixNQUFNLE9BQU8sR0FBRyxpQkFBVSxDQUFDLFdBQVcsRUFBRSxPQUFPLENBQUMsQ0FBQTtJQUNoRCxNQUFNLFFBQVEsR0FBRyxNQUFNLGVBQUssQ0FBQztRQUN6QixHQUFHLEVBQ0MsV0FBSSxDQUFDLFlBQVk7WUFDakIsaURBQWlEO1lBQ2pELE1BQU07WUFDTixNQUFNO1FBQ1YsTUFBTSxFQUFFLEtBQUs7UUFDYixPQUFPO0tBQ1YsQ0FBQyxDQUFBO0lBRUYsT0FBTyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUE7QUFDM0IsQ0FBQyxDQUFBO0FBRUQ7Ozs7Ozs7OztHQVNHO0FBQ1UsUUFBQSx3QkFBd0IsR0FBRyxLQUFLLEVBQ3pDLFdBQW1CLEVBQ25CLE1BQWMsRUFDUSxFQUFFO0lBQ3hCLE1BQU0sT0FBTyxHQUFHLGlCQUFVLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxDQUFBO0lBQ2hELE1BQU0sUUFBUSxHQUFHLE1BQU0sZUFBSyxDQUFDO1FBQ3pCLEdBQUcsRUFDQyxXQUFJLENBQUMsWUFBWTtZQUNqQixpREFBaUQ7WUFDakQsTUFBTTtZQUNOLGVBQWU7UUFDbkIsTUFBTSxFQUFFLEtBQUs7UUFDYixPQUFPO0tBQ1YsQ0FBQyxDQUFBO0lBRUYsT0FBTyxRQUFRLENBQUMsTUFBTSxDQUFDLENBQUE7QUFDM0IsQ0FBQyxDQUFBO0FBRUQ7Ozs7Ozs7Ozs7OztHQVlHO0FBQ1UsUUFBQSxZQUFZLEdBQUcsS0FBSyxFQUM3QixXQUFtQixFQUNuQixTQUFpQixDQUFDLEVBQ2xCLFNBQWlCLEVBQUUsRUFDbkIsT0FBZSxZQUFZLEVBQzNCLFFBQWdCLE1BQU0sRUFDSCxFQUFFO0lBQ3JCLE1BQU0sT0FBTyxHQUFHLGlCQUFVLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxDQUFBO0lBQ2hELE1BQU0sUUFBUSxHQUFHLE1BQU0sZUFBSyxDQUFDO1FBQ3pCLEdBQUcsRUFDQyxXQUFJLENBQUMsWUFBWTtZQUNqQiw4QkFBOEI7WUFDOUIsTUFBTTtZQUNOLFVBQVU7WUFDVixNQUFNO1lBQ04sUUFBUTtZQUNSLElBQUk7WUFDSixTQUFTO1lBQ1QsS0FBSztRQUNULE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7OztHQVFHO0FBQ1UsUUFBQSxjQUFjLEdBQUcsS0FBSyxFQUFFLFdBQW1CLEVBQXlCLEVBQUU7SUFDL0UsTUFBTSxPQUFPLEdBQUcsaUJBQVUsQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLENBQUE7SUFDaEQsTUFBTSxRQUFRLEdBQUcsTUFBTSxlQUFLLENBQUM7UUFDekIsR0FBRyxFQUFFLFdBQUksQ0FBQyxZQUFZLEdBQUcsaUNBQWlDO1FBQzFELE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7Ozs7O0dBVUc7QUFDVSxRQUFBLFFBQVEsR0FBRyxLQUFLLEVBQ3pCLFdBQW1CLEVBQ25CLFNBQWlCLENBQUMsRUFDbEIsU0FBaUIsRUFBRSxFQUNKLEVBQUU7SUFDakIsTUFBTSxPQUFPLEdBQUcsaUJBQVUsQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLENBQUE7SUFDaEQsTUFBTSxRQUFRLEdBQUcsTUFBTSxlQUFLLENBQUM7UUFDekIsR0FBRyxFQUNDLFdBQUksQ0FBQyxZQUFZO1lBQ2pCLDhCQUE4QjtZQUM5QixNQUFNO1lBQ04sVUFBVTtZQUNWLE1BQU07UUFDVixNQUFNLEVBQUUsS0FBSztRQUNiLE9BQU87S0FDVixDQUFDLENBQUE7SUFFRixPQUFPLFFBQVEsQ0FBQyxNQUFNLENBQUMsQ0FBQTtBQUMzQixDQUFDLENBQUE7QUFFRDs7Ozs7Ozs7Ozs7R0FXRztBQUNVLFFBQUEsY0FBYyxHQUFHLEtBQUssRUFDL0IsV0FBbUIsRUFDbkIsTUFBYyxFQUNkLFNBQWlCLENBQUMsRUFDbEIsU0FBaUIsRUFBRSxFQUNFLEVBQUU7SUFDdkIsTUFBTSxPQUFPLEdBQUcsaUJBQVUsQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLENBQUE7SUFDaEQsTUFBTSxRQUFRLEdBQUcsTUFBTSxlQUFLLENBQUM7UUFDekIsR0FBRyxFQUNDLFdBQUksQ0FBQyxZQUFZO1lBQ2pCLGtCQUFrQjtZQUNsQixNQUFNO1lBQ04saUJBQWlCO1lBQ2pCLE1BQU07WUFDTixVQUFVO1lBQ1YsTUFBTTtRQUNWLE1BQU0sRUFBRSxLQUFLO1FBQ2IsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQTtBQUVEOzs7Ozs7Ozs7R0FTRztBQUNVLFFBQUEsaUJBQWlCLEdBQUcsS0FBSyxFQUFFLFdBQW1CLEVBQUUsVUFBb0IsRUFBRSxFQUFFO0lBQ2pGLE1BQU0sR0FBRyxHQUFHLFVBQVUsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLEVBQUU7UUFDNUIsT0FBTyxFQUFFLFNBQVMsRUFBRSxFQUFFLEVBQUUsQ0FBQTtJQUM1QixDQUFDLENBQUMsQ0FBQTtJQUNGLE1BQU0sT0FBTyxHQUFHLGlCQUFVLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxDQUFBO0lBQ2hELE1BQU0sUUFBUSxHQUFHLE1BQU0sZUFBSyxDQUFDO1FBQ3pCLEdBQUcsRUFBRSxXQUFJLENBQUMsWUFBWSxHQUFHLHNDQUFzQztRQUMvRCxNQUFNLEVBQUUsTUFBTTtRQUNkLElBQUksRUFBRTtZQUNGLFVBQVUsRUFBRSxHQUFHO1NBQ2xCO1FBQ0QsT0FBTztLQUNWLENBQUMsQ0FBQTtJQUVGLE9BQU8sUUFBUSxDQUFDLE1BQU0sQ0FBQyxDQUFBO0FBQzNCLENBQUMsQ0FBQSJ9


### PR DESCRIPTION
getClubCampaignById allows to access to a campaign using its club ID and its campaign ID.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduce the new geyClubCampaignById.
It allows to access to a campaign by its club ID and its campaign ID.



* **What is the current behavior?** (You can also link to an open issue here)
//



* **What is the new behavior (if this is a feature change)?**
Explained in the introduction


* **Other information**:
I tried to implement it but I'm not sure if it works exactly like I did.
If you could check, it's working but my declarations may be false.

Here are the changes :
- live-services.js : from line 88 to line 111
- live-services.d.ts : from line 40 to line 51 and from line 286 to line 299

Thanks for reading it and please let me know if I need to fix things !
(if you want an example of the JSON that is returning, just ask me, but I think it's the same as campaigns from getClubCampaigns)
